### PR TITLE
add Formats class for commonly used parsers

### DIFF
--- a/src/main/java/com/github/davidmoten/aws/lw/client/Formats.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Formats.java
@@ -1,0 +1,26 @@
+package com.github.davidmoten.aws.lw.client;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public final class Formats {
+
+    private Formats() {
+        // prevent instantiation
+    }
+
+    /**
+     * A common date-time format used in the AWS API. For example {@code Last-Modified}
+     * header for an S3 object uses this format.
+     * 
+     * <p>
+     * See <a href=
+     * "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html">Common
+     * Request Headers</a> and <a href=
+     * "https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html">Common
+     * Response Headers</a>.
+     */
+    public static final DateTimeFormatter FULL_DATE = DateTimeFormatter //
+            .ofPattern("EEE, d MMM yyyy HH:mm:ss z", Locale.ENGLISH);
+
+}

--- a/src/test/java/com/github/davidmoten/aws/lw/client/FormatsTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/FormatsTest.java
@@ -1,0 +1,19 @@
+package com.github.davidmoten.aws.lw.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.time.temporal.TemporalAccessor;
+
+import org.junit.Test;
+
+public class FormatsTest {
+    
+    @Test
+    public void testFullDate() {
+        String s = "Wed, 25 Aug 2021 21:55:47 GMT";
+        TemporalAccessor t = Formats.FULL_DATE.parse(s);
+        assertEquals(1629928547000L, Instant.from(t).toEpochMilli());
+    }
+
+}


### PR DESCRIPTION
especially Formats.FULL_DATE for a commonly used date-time request or response header