### PR TITLE
support no-region endpoints like iam.amazonaws.com

### DIFF
--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -1,5 +1,6 @@
 package com.github.davidmoten.aws.lw.client;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -13,14 +14,14 @@ public final class Client {
 
     private final Clock clock;
     private final String serviceName;
-    private final String region;
+    private final Optional<String> region;
     private final Credentials credentials;
     private final HttpClient httpClient;
     private final int connectTimeoutMs;
     private final int readTimeoutMs;
     private final ExceptionFactory exceptionFactory;
 
-    private Client(Clock clock, String serviceName, String region, Credentials credentials,
+    private Client(Clock clock, String serviceName, Optional<String> region, Credentials credentials,
             HttpClient httpClient, int connectTimeoutMs, int readTimeoutMs,
             ExceptionFactory exceptionFactory) {
         this.clock = clock;
@@ -75,7 +76,7 @@ public final class Client {
         return serviceName;
     }
 
-    public String region() {
+    public Optional<String> region() {
         return region;
     }
 
@@ -138,7 +139,7 @@ public final class Client {
     public static final class Builder {
 
         private final String serviceName;
-        private String region;
+        private Optional<String> region = Optional.empty();
         private String accessKey;
         private Credentials credentials;
         private HttpClient httpClient = HttpClient.defaultClient();
@@ -178,10 +179,15 @@ public final class Client {
             return region(environment.get("AWS_REGION"));
         }
 
-        public Builder2 region(String region) {
+        public Builder2 region(Optional<String> region) {
             Preconditions.checkNotNull(region, "region cannot be null");
             this.region = region;
             return new Builder2(this);
+        }
+        
+        public Builder2 region(String region) {
+            Preconditions.checkNotNull(region, "region cannot be null");
+            return region(Optional.of(region));
         }
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -189,6 +189,10 @@ public final class Client {
             Preconditions.checkNotNull(region, "region cannot be null");
             return region(Optional.of(region));
         }
+
+		public Builder2 regionNone() {
+			return region(Optional.empty());
+		}
     }
 
     public static final class Builder2 {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -19,7 +19,7 @@ import com.github.davidmoten.aws.lw.client.xml.XmlElement;
 public final class Request {
 
     private final Client client;
-    private String region;
+    private Optional<String> region;
     private String url;
     private HttpMethod method = HttpMethod.GET;
     private final Map<String, List<String>> headers = new HashMap<>();
@@ -114,7 +114,7 @@ public final class Request {
 
     public Request region(String region) {
         Preconditions.checkNotNull(region);
-        this.region = region;
+        this.region = Optional.of(region);
         return this;
     }
 
@@ -195,14 +195,13 @@ public final class Request {
                 || r.header("Transfer-Encoding").orElse("").equalsIgnoreCase("chunked");
     }
 
-    private static String calculateUrl(String url, String serviceName, String region,
+    private static String calculateUrl(String url, String serviceName, Optional<String> region,
             List<NameValue> queries, List<String> pathSegments) {
         String u = url;
         if (u == null) {
             u = "https://" //
                     + serviceName //
-                    + "." //
-                    + region //
+                    + region.map(x -> "." + x).orElse("") //
                     + ".amazonaws.com/" //
                     + pathSegments //
                             .stream() //

--- a/src/main/java/com/github/davidmoten/aws/lw/client/RequestHelper.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/RequestHelper.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.github.davidmoten.aws.lw.client.internal.Clock;
@@ -41,7 +42,7 @@ final class RequestHelper {
     }
 
     static String presignedUrl(Clock clock, String url, String method, Map<String, String> headers,
-            byte[] requestBody, String serviceName, String regionName, Credentials credentials,
+            byte[] requestBody, String serviceName, Optional<String> regionName, Credentials credentials,
             int connectTimeoutMs, int readTimeoutMs, long expirySeconds, boolean signPayload) {
 
         // the region-specific endpoint to the target object expressed in path style
@@ -98,7 +99,7 @@ final class RequestHelper {
 
     static ResponseInputStream request(Clock clock, HttpClient httpClient, String url,
             HttpMethod method, Map<String, String> headers, byte[] requestBody, String serviceName,
-            String regionName, Credentials credentials, int connectTimeoutMs, int readTimeoutMs, //
+            Optional<String> regionName, Credentials credentials, int connectTimeoutMs, int readTimeoutMs, //
             boolean signPayload) throws IOException {
 
         // the region-specific endpoint to the target object expressed in path style
@@ -127,7 +128,7 @@ final class RequestHelper {
         Map<String, String> q = new HashMap<>();
         parameters.forEach(p -> q.put(p.name, p.value));
         String authorization = AwsSignatureVersion4.computeSignatureForAuthorizationHeader(
-                endpointUrl, method.toString(), serviceName, regionName, clock, h, q,
+                endpointUrl, method.toString(), serviceName, regionName.orElse("us-east-1"), clock, h, q,
                 contentHashString, credentials.accessKey(), credentials.secretKey());
 
         // place the computed signature into a formatted 'Authorization' header

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/auth/AwsSignatureVersion4.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/auth/AwsSignatureVersion4.java
@@ -72,7 +72,7 @@ public final class AwsSignatureVersion4 {
      *         request.
      */
     public static String computeSignatureForQueryAuth(URL endpointUrl, String httpMethod,
-            String serviceName, String regionName, Clock clock, Map<String, String> headers,
+            String serviceName, Optional<String> regionName, Clock clock, Map<String, String> headers,
             Map<String, String> queryParameters, String bodyHash, String awsAccessKey,
             String awsSecretKey, Optional<String> sessionToken) {
         // first get the date and time for the subsequent request, and convert
@@ -95,7 +95,7 @@ public final class AwsSignatureVersion4 {
 
         // we need scope as part of the query parameters
         String dateStamp = dateStampFormat().format(now);
-        String scope = dateStamp + "/" + regionName + "/" + serviceName + "/" + TERMINATOR;
+        String scope = dateStamp + "/" + regionName.orElse("us-east-1") + "/" + serviceName + "/" + TERMINATOR;
 
         // add the fixed authorization params required by Signature V4
         queryParameters.put("X-Amz-Algorithm", SCHEME + "-" + ALGORITHM);
@@ -130,7 +130,7 @@ public final class AwsSignatureVersion4 {
         // compute the signing key
         byte[] kSecret = (SCHEME + awsSecretKey).getBytes(StandardCharsets.UTF_8);
         byte[] kDate = sign(dateStamp, kSecret);
-        byte[] kRegion = sign(regionName, kDate);
+        byte[] kRegion = sign(regionName.orElse("us-east-1"), kDate);
         byte[] kService = sign(serviceName, kRegion);
         byte[] kSigning = sign(TERMINATOR, kService);
         byte[] signature = sign(stringToSign, kSigning);

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -225,7 +225,7 @@ public class ClientTest {
         map.put("AWS_ACCESS_KEY_ID", "123");
         map.put("AWS_SECRET_ACCESS_KEY", "abc");
         Client client = Client.s3().environment(name -> map.get(name)).defaultClient().build();
-        assertEquals("ap-southeast-2", client.region());
+        assertEquals("ap-southeast-2", client.region().get());
         Credentials c = client.credentials();
         assertEquals("123", c.accessKey());
         assertEquals("abc", c.secretKey());
@@ -238,7 +238,7 @@ public class ClientTest {
         System.setProperty("aws.secretKey", "abc");
         Client client = Client.s3().region("ap-southeast-2").credentialsFromSystemProperties()
                 .build();
-        assertEquals("ap-southeast-2", client.region());
+        assertEquals("ap-southeast-2", client.region().get());
         Credentials c = client.credentials();
         assertEquals("123", c.accessKey());
         assertEquals("abc", c.secretKey());

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -144,6 +144,28 @@ public class ClientTest {
         assertEquals(5000, hc.connectTimeoutMs);
         assertEquals(6000, hc.readTimeoutMs);
     }
+    
+    @Test
+    public void testRegionNoneUsesUsEast1InSignature() {
+        Client client = Client //
+                .iam() //
+                .regionNone()
+                .accessKey("123") //
+                .secretKey("456") //
+                .httpClient(hc) //
+                .build();
+        // create a bucket
+        client //
+                .query("Action", "GetUser") //
+                .query("Version", "2010-05-08") //
+                .execute();
+        assertEquals(
+                "https://iam.amazonaws.com/?Action=GetUser&Version=2010-05-08",
+                hc.endpointUrl.toString());
+        String authorization = hc.headers.get("Authorization");
+        assertTrue(authorization.contains("/us-east-1/iam/aws4_request"));
+        assertEquals("iam.amazonaws.com", hc.headers.get("Host"));
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testBadConnectTimeout() {


### PR DESCRIPTION
Adds method `.regionNone()` to builder so that endpoint doesn't use a region in the hostname and AWS Signature v4 calculation uses `us-east-1`.