### PR TITLE
support custom base urls in requests

### DIFF
--- a/src/main/java/com/github/davidmoten/aws/lw/client/BaseUrlFactory.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/BaseUrlFactory.java
@@ -1,0 +1,15 @@
+package com.github.davidmoten.aws.lw.client;
+
+import java.util.Optional;
+
+@FunctionalInterface
+public interface BaseUrlFactory {
+
+    String create(String serviceName, Optional<String> region);
+
+    public static final BaseUrlFactory DEFAULT = (serviceName, region) -> "https://" //
+            + serviceName //
+            + region.map(x -> "." + x).orElse("") //
+            + ".amazonaws.com/";
+
+}

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -20,10 +20,11 @@ public final class Client {
     private final int connectTimeoutMs;
     private final int readTimeoutMs;
     private final ExceptionFactory exceptionFactory;
+    private final BaseUrlFactory baseUrlFactory;
 
     private Client(Clock clock, String serviceName, Optional<String> region, Credentials credentials,
             HttpClient httpClient, int connectTimeoutMs, int readTimeoutMs,
-            ExceptionFactory exceptionFactory) {
+            ExceptionFactory exceptionFactory, BaseUrlFactory baseUrlFactory) {
         this.clock = clock;
         this.serviceName = serviceName;
         this.region = region;
@@ -32,6 +33,7 @@ public final class Client {
         this.connectTimeoutMs = connectTimeoutMs;
         this.readTimeoutMs = readTimeoutMs;
         this.exceptionFactory = exceptionFactory;
+        this.baseUrlFactory = baseUrlFactory;
     }
 
     public static Builder service(String serviceName) {
@@ -95,6 +97,10 @@ public final class Client {
     ExceptionFactory exceptionFactory() {
         return exceptionFactory;
     }
+    
+    BaseUrlFactory baseUrlFactory() {
+        return baseUrlFactory;
+    }
 
     int connectTimeoutMs() {
         return connectTimeoutMs;
@@ -148,7 +154,8 @@ public final class Client {
         private ExceptionFactory exceptionFactory = ExceptionFactory.DEFAULT;
         private Clock clock = Clock.DEFAULT;
         private Environment environment = Environment.instance();
-
+        private BaseUrlFactory baseUrlFactory = BaseUrlFactory.DEFAULT;
+        
         private Builder(String serviceName) {
             this.serviceName = serviceName;
         }
@@ -159,7 +166,7 @@ public final class Client {
             this.environment = environment;
             return this;
         }
-
+        
         public Builder4 defaultClient() {
             return regionFromEnvironment().credentialsFromEnvironment();
         }
@@ -244,6 +251,11 @@ public final class Client {
         private Builder4(Builder b) {
             this.b = b;
         }
+        
+        public Builder4 baseUrlFactory(BaseUrlFactory factory) {
+            b.baseUrlFactory = factory;
+            return this;
+        }
 
         public Builder4 httpClient(HttpClient httpClient) {
             b.httpClient = httpClient;
@@ -283,7 +295,7 @@ public final class Client {
 
         public Client build() {
             return new Client(b.clock, b.serviceName, b.region, b.credentials, b.httpClient,
-                    b.connectTimeoutMs, b.readTimeoutMs, b.exceptionFactory);
+                    b.connectTimeoutMs, b.readTimeoutMs, b.exceptionFactory, b.baseUrlFactory);
         }
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -142,7 +142,7 @@ public final class Request {
      */
     public ResponseInputStream responseInputStream() {
         String u = calculateUrl(url, client.serviceName(), region, queries,
-                Arrays.asList(pathSegments));
+                Arrays.asList(pathSegments), client.baseUrlFactory());
         try {
             return RequestHelper.request(client.clock(), client.httpClient(), u, method,
                     RequestHelper.combineHeaders(headers), requestBody, client.serviceName(),
@@ -196,13 +196,10 @@ public final class Request {
     }
 
     private static String calculateUrl(String url, String serviceName, Optional<String> region,
-            List<NameValue> queries, List<String> pathSegments) {
+            List<NameValue> queries, List<String> pathSegments, BaseUrlFactory baseUrlFactory) {
         String u = url;
         if (u == null) {
-            u = "https://" //
-                    + serviceName //
-                    + region.map(x -> "." + x).orElse("") //
-                    + ".amazonaws.com/" //
+            u = baseUrlFactory.create(serviceName, region) //
                     + pathSegments //
                             .stream() //
                             .map(x -> trimAndRemoveLeadingAndTrailingSlashes(x)) //
@@ -261,7 +258,7 @@ public final class Request {
 
     public String presignedUrl(long expiryDuration, TimeUnit unit) {
         String u = calculateUrl(url, client.serviceName(), region, queries,
-                Arrays.asList(pathSegments));
+                Arrays.asList(pathSegments), client.baseUrlFactory());
         return RequestHelper.presignedUrl(client.clock(), u, method.toString(),
                 RequestHelper.combineHeaders(headers), requestBody, client.serviceName(), region,
                 client.credentials(), connectTimeoutMs, readTimeoutMs,

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -102,6 +102,8 @@ public class MultipartTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .httpClient(h) //
+                .baseUrlFactory((serviceName, region) //
+                        -> "https://"+ serviceName + "." + region.map(x -> x + ".").orElse("") + "mine.com/") //
                 .build();
         h.add(startMultipartUpload());
         h.add(submitPart1());
@@ -120,11 +122,11 @@ public class MultipartTest {
             consumer.accept(out);
         }
         assertEquals(Arrays.asList( //
-                "POST:https://s3.ap-southeast-2.amazonaws.com/mybucket/mykey?uploads",
-                "PUT:https://s3.ap-southeast-2.amazonaws.com/mybucket/mykey?partNumber=1&uploadId=abcde",
-                "PUT:https://s3.ap-southeast-2.amazonaws.com/mybucket/mykey?partNumber=2&uploadId=abcde",
-                "PUT:https://s3.ap-southeast-2.amazonaws.com/mybucket/mykey?partNumber=2&uploadId=abcde",
-                "POST:https://s3.ap-southeast-2.amazonaws.com/mybucket/mykey?uploadId=abcde"), //
+                "POST:https://s3.ap-southeast-2.mine.com/mybucket/mykey?uploads",
+                "PUT:https://s3.ap-southeast-2.mine.com/mybucket/mykey?partNumber=1&uploadId=abcde",
+                "PUT:https://s3.ap-southeast-2.mine.com/mybucket/mykey?partNumber=2&uploadId=abcde",
+                "PUT:https://s3.ap-southeast-2.mine.com/mybucket/mykey?partNumber=2&uploadId=abcde",
+                "POST:https://s3.ap-southeast-2.mine.com/mybucket/mykey?uploadId=abcde"), //
                 h.urls());
         assertArrayEquals(createBytes(), h.bytes());
     }


### PR DESCRIPTION
As discussed in #50, this PR adds a new builder method that allows customization of the base URL used for requests:

```java
Client s3 = Client
  .s3()
  .region("ap-southeast-2")
  .accessKey(accessKey)
  .secretKey(secretKey)
  .baseUrlFactory((service, region) -> "https://" + service + ".mine.com/")
  .build();
```

