### PR TITLE
Add automatic retry logic throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ Client s3 = Client
 Automatic retries can be configured in the client builder and also for each request including multipart requests. Capped
 exponential backoff is supported as is jitter (randomised intervals):
 
+Default behaviour (that can be overridden) is to retry these HTTP status codes:
+
+```
+400, 403, 429, 500, 502, 503, 509
+```
+When the http client throws an exception it is retried if it is an `IOException` or an `UncheckedIOException`.
+
 ```java
 Client s3 = Client
   .s3()
@@ -215,6 +222,7 @@ Client s3 = Client
   .retryBackoffFactor(2.0)
   .retryMaxInterval(30, TimeUnit.SECONDS)
   .retryJitter(0.5)
+  .retryStatusCodes(400, 403, 429, 500, 502, 503)
   .build();
 ```
 The same options are available on request builders:

--- a/README.md
+++ b/README.md
@@ -223,9 +223,10 @@ Client s3 = Client
   .retryMaxInterval(30, TimeUnit.SECONDS)
   .retryJitter(0.5)
   .retryStatusCodes(400, 403, 429, 500, 502, 503)
+  .retryException(e -> false) // never retry exceptions
   .build();
 ```
-The same options are available on request builders:
+Most of the same options are available on request builders:
 ```java
 String content = s3
     .path("myBucket", "myObject.txt")

--- a/README.md
+++ b/README.md
@@ -202,6 +202,32 @@ Client s3 = Client
     .readTimeout(5, TimeUnit.SECONDS)
     .responseAsUtf8();
 ```
+### Retries
+Automatic retries can be configured in the client builder and also for each request including multipart requests. Capped
+exponential backoff is supported as is jitter (randomised intervals):
+
+```java
+Client s3 = Client
+  .s3()
+  .defaultClient()
+  .retryMaxAttempts(10)
+  .retryInitialInterval(100, TimeUnit.MILLISECONDS)
+  .retryBackoffFactor(2.0)
+  .retryMaxInterval(30, TimeUnit.SECONDS)
+  .retryJitter(0.5)
+  .build();
+```
+The same options are available on request builders:
+```java
+String content = s3
+    .path("myBucket", "myObject.txt")
+    .connectTimeout(5, TimeUnit.SECONDS)
+    .readTimeout(5, TimeUnit.SECONDS)
+    .retryMaxAttempts(3)
+    .retryInitialInterval(5, TimeUnit.SECONDS)
+    .responseAsUtf8();
+```
+
 ### Presigned URLs
 Presigned URLs are generated as follows (with a specified expiry duration):
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ String content = s3
     .retryInitialInterval(5, TimeUnit.SECONDS)
     .responseAsUtf8();
 ```
+You can also completely control the request retry (when there is an HTTP status code) via this builder method:
+```java
+Client s3 = Client
+  .s3()
+  .defaultClient()
+  .retryCondition(ris -> ris.statusCode() == 500)
+...
+```
 
 ### Presigned URLs
 Presigned URLs are generated as follows (with a specified expiry duration):

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -279,6 +279,16 @@ public final class Client {
             b.retries.maxAttempts = maxAttempts;
             return this;
         }
+        
+        public Builder4 backoffFactor(double factor) {
+            b.retries.backoffFactor = factor;
+            return this;
+        }
+        
+        public Builder4 maxIntervalMs(long maxIntervalMs) {
+            b.retries.maxIntervalMs = maxIntervalMs;
+            return this;
+        }
 
         public Builder4 connectTimeout(long duration, TimeUnit unit) {
             Preconditions.checkArgument(duration >= 0, "duration cannot be negative");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -3,6 +3,7 @@ package com.github.davidmoten.aws.lw.client;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -324,6 +325,19 @@ public final class Client {
         public Builder4 retryJitter(double jitter) {
             Preconditions.checkArgument(jitter >= 0 && jitter <= 1, "jitter must be between 0 and 1");
             b.retries = b.retries.withJitter(jitter);
+            return this;
+        }
+        
+        public Builder4 retryShouldRetry(Predicate<? super ResponseInputStream> shouldRetry) {
+            Preconditions.checkNotNull(shouldRetry, "shouldRetry cannot be null");
+            b.retries = b.retries.withValueShouldRetry(shouldRetry);
+            return this;
+        }
+
+        public Builder4 retryableStatusCodes(Collection<Integer> statusCodes) {
+            Preconditions.checkNotNull(statusCodes, "statusCodes cannot be null");
+            Set<Integer> set = new HashSet<>(statusCodes);
+            b.retries = b.retries.withValueShouldRetry(ris -> set.contains(ris.statusCode()));
             return this;
         }
         

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -350,6 +350,18 @@ public final class Client {
             return retryCondition(ris -> set.contains(ris.statusCode()));
         }
         
+        /**
+         * Default behaviour is to retry IOException and UncheckedIOException.
+         * 
+         * @param shouldRetry returns true if should retry
+         * @return this
+         */
+        public Builder4 retryException(Predicate<? super Throwable> shouldRetry) {
+            Preconditions.checkNotNull(shouldRetry, "shouldRetry cannot be null");
+            b.retries = b.retries.withThrowableShouldRetry(shouldRetry);
+            return this;
+        }
+        
         public Builder4 connectTimeout(long duration, TimeUnit unit) {
             Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
             Preconditions.checkNotNull(unit, "unit cannot be null");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -22,11 +22,11 @@ public final class Client {
     private final int readTimeoutMs;
     private final ExceptionFactory exceptionFactory;
     private final BaseUrlFactory baseUrlFactory;
-    private final Retries retries;
+    private final Retries<ResponseInputStream> retries;
 
     private Client(Clock clock, String serviceName, Optional<String> region, Credentials credentials,
-            HttpClient httpClient, int connectTimeoutMs, int readTimeoutMs,
-            ExceptionFactory exceptionFactory, BaseUrlFactory baseUrlFactory, Retries retries) {
+            HttpClient httpClient, int connectTimeoutMs, int readTimeoutMs, ExceptionFactory exceptionFactory,
+            BaseUrlFactory baseUrlFactory, Retries<ResponseInputStream> retries) {
         this.clock = clock;
         this.serviceName = serviceName;
         this.region = region;
@@ -100,7 +100,7 @@ public final class Client {
     ExceptionFactory exceptionFactory() {
         return exceptionFactory;
     }
-    
+
     BaseUrlFactory baseUrlFactory() {
         return baseUrlFactory;
     }
@@ -112,8 +112,8 @@ public final class Client {
     int readTimeoutMs() {
         return readTimeoutMs;
     }
-    
-    Retries retries() {
+
+    Retries<ResponseInputStream> retries() {
         return retries;
     }
 
@@ -162,8 +162,8 @@ public final class Client {
         private Clock clock = Clock.DEFAULT;
         private Environment environment = Environment.instance();
         private BaseUrlFactory baseUrlFactory = BaseUrlFactory.DEFAULT;
-        private Retries retries = new Retries();
-        
+        private Retries<ResponseInputStream> retries = Retries.requestRetries();
+
         private Builder(String serviceName) {
             this.serviceName = serviceName;
         }
@@ -174,7 +174,7 @@ public final class Client {
             this.environment = environment;
             return this;
         }
-        
+
         public Builder4 defaultClient() {
             return regionFromEnvironment().credentialsFromEnvironment();
         }
@@ -199,15 +199,15 @@ public final class Client {
             this.region = region;
             return new Builder2(this);
         }
-        
+
         public Builder2 region(String region) {
             Preconditions.checkNotNull(region, "region cannot be null");
             return region(Optional.of(region));
         }
 
-		public Builder2 regionNone() {
-			return region(Optional.empty());
-		}
+        public Builder2 regionNone() {
+            return region(Optional.empty());
+        }
     }
 
     public static final class Builder2 {
@@ -259,7 +259,7 @@ public final class Client {
         private Builder4(Builder b) {
             this.b = b;
         }
-        
+
         public Builder4 baseUrlFactory(BaseUrlFactory factory) {
             b.baseUrlFactory = factory;
             return this;
@@ -269,22 +269,22 @@ public final class Client {
             b.httpClient = httpClient;
             return this;
         }
-        
+
         public Builder4 retryInitialIntervalMs(long initialIntervalMs) {
             b.retries.initialIntervalMs = initialIntervalMs;
             return this;
         }
-        
+
         public Builder4 retryMaxAttempts(int maxAttempts) {
             b.retries.maxAttempts = maxAttempts;
             return this;
         }
-        
+
         public Builder4 retryBackoffFactor(double factor) {
             b.retries.backoffFactor = factor;
             return this;
         }
-        
+
         public Builder4 retryMaxIntervalMs(long maxIntervalMs) {
             b.retries.maxIntervalMs = maxIntervalMs;
             return this;
@@ -311,8 +311,7 @@ public final class Client {
 
         public Builder4 exception(Predicate<? super Response> predicate,
                 Function<? super Response, ? extends RuntimeException> factory) {
-            b.exceptionFactory = new ExceptionFactoryExtended(b.exceptionFactory, predicate,
-                    factory);
+            b.exceptionFactory = new ExceptionFactoryExtended(b.exceptionFactory, predicate, factory);
             return this;
         }
 
@@ -322,8 +321,8 @@ public final class Client {
         }
 
         public Client build() {
-            return new Client(b.clock, b.serviceName, b.region, b.credentials, b.httpClient,
-                    b.connectTimeoutMs, b.readTimeoutMs, b.exceptionFactory, b.baseUrlFactory, b.retries);
+            return new Client(b.clock, b.serviceName, b.region, b.credentials, b.httpClient, b.connectTimeoutMs,
+                    b.readTimeoutMs, b.exceptionFactory, b.baseUrlFactory, b.retries);
         }
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -312,6 +312,21 @@ public final class Client {
             return this;
         }
         
+        /**
+         * Sets the level of randomness applied to the next retry interval. The next
+         * calculated retry interval is multiplied by
+         * {@code (1 - jitter * Math.random())}. A value of zero means no jitter, 1
+         * means max jitter.
+         * 
+         * @param jitter level of randomness applied to the retry interval
+         * @return this
+         */
+        public Builder4 retryJitter(double jitter) {
+            Preconditions.checkArgument(jitter >= 0 && jitter <= 1, "jitter must be between 0 and 1");
+            b.retries = b.retries.withJitter(jitter);
+            return this;
+        }
+        
         public Builder4 connectTimeout(long duration, TimeUnit unit) {
             Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
             Preconditions.checkNotNull(unit, "unit cannot be null");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -328,17 +328,20 @@ public final class Client {
             return this;
         }
         
-        public Builder4 retryShouldRetry(Predicate<? super ResponseInputStream> shouldRetry) {
+        public Builder4 retryCondition(Predicate<? super ResponseInputStream> shouldRetry) {
             Preconditions.checkNotNull(shouldRetry, "shouldRetry cannot be null");
             b.retries = b.retries.withValueShouldRetry(shouldRetry);
             return this;
         }
 
-        public Builder4 retryableStatusCodes(Collection<Integer> statusCodes) {
+        public Builder4 retryStatusCodes(Integer... statusCodes) {
+            return retryStatusCodes(Arrays.asList(statusCodes));
+        }
+        
+        public Builder4 retryStatusCodes(Collection<Integer> statusCodes) {
             Preconditions.checkNotNull(statusCodes, "statusCodes cannot be null");
             Set<Integer> set = new HashSet<>(statusCodes);
-            b.retries = b.retries.withValueShouldRetry(ris -> set.contains(ris.statusCode()));
-            return this;
+            return retryCondition(ris -> set.contains(ris.statusCode()));
         }
         
         public Builder4 connectTimeout(long duration, TimeUnit unit) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -275,17 +275,17 @@ public final class Client {
             return this;
         }
         
-        public Builder4 maxAttempts(int maxAttempts) {
+        public Builder4 retryMaxAttempts(int maxAttempts) {
             b.retries.maxAttempts = maxAttempts;
             return this;
         }
         
-        public Builder4 backoffFactor(double factor) {
+        public Builder4 retryBackoffFactor(double factor) {
             b.retries.backoffFactor = factor;
             return this;
         }
         
-        public Builder4 maxIntervalMs(long maxIntervalMs) {
+        public Builder4 retryMaxIntervalMs(long maxIntervalMs) {
             b.retries.maxIntervalMs = maxIntervalMs;
             return this;
         }

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -269,6 +269,16 @@ public final class Client {
             b.httpClient = httpClient;
             return this;
         }
+        
+        public Builder4 retryInitialIntervalMs(long initialIntervalMs) {
+            b.retries.initialIntervalMs = initialIntervalMs;
+            return this;
+        }
+        
+        public Builder4 maxAttempts(int maxAttempts) {
+            b.retries.maxAttempts = maxAttempts;
+            return this;
+        }
 
         public Builder4 connectTimeout(long duration, TimeUnit unit) {
             Preconditions.checkArgument(duration >= 0, "duration cannot be negative");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -286,9 +286,9 @@ public final class Client {
             return this;
         }
 
-        public Builder4 retryInitialIntervalMs(long initialIntervalMs) {
-            Preconditions.checkArgument(initialIntervalMs >= 0);
-            b.retries = b.retries.withInitialIntervalMs( initialIntervalMs);
+        public Builder4 retryInitialInterval(long duration, TimeUnit unit) {
+            Preconditions.checkArgument(duration >= 0);
+            b.retries = b.retries.withInitialIntervalMs(unit.toMillis(duration));
             return this;
         }
 
@@ -304,9 +304,9 @@ public final class Client {
             return this;
         }
 
-        public Builder4 retryMaxIntervalMs(long maxIntervalMs) {
-            Preconditions.checkArgument(maxIntervalMs >= 0);
-            b.retries = b.retries.withMaxIntervalMs(maxIntervalMs);
+        public Builder4 retryMaxInterval(long duration, TimeUnit unit) {
+            Preconditions.checkArgument(duration >= 0);
+            b.retries = b.retries.withMaxIntervalMs(unit.toMillis(duration));
             return this;
         }
         

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 import com.github.davidmoten.aws.lw.client.internal.Clock;
 import com.github.davidmoten.aws.lw.client.internal.Environment;
 import com.github.davidmoten.aws.lw.client.internal.ExceptionFactoryExtended;
+import com.github.davidmoten.aws.lw.client.internal.Retries;
 import com.github.davidmoten.aws.lw.client.internal.util.Preconditions;
 
 public final class Client {
@@ -21,10 +22,11 @@ public final class Client {
     private final int readTimeoutMs;
     private final ExceptionFactory exceptionFactory;
     private final BaseUrlFactory baseUrlFactory;
+    private final Retries retries;
 
     private Client(Clock clock, String serviceName, Optional<String> region, Credentials credentials,
             HttpClient httpClient, int connectTimeoutMs, int readTimeoutMs,
-            ExceptionFactory exceptionFactory, BaseUrlFactory baseUrlFactory) {
+            ExceptionFactory exceptionFactory, BaseUrlFactory baseUrlFactory, Retries retries) {
         this.clock = clock;
         this.serviceName = serviceName;
         this.region = region;
@@ -34,6 +36,7 @@ public final class Client {
         this.readTimeoutMs = readTimeoutMs;
         this.exceptionFactory = exceptionFactory;
         this.baseUrlFactory = baseUrlFactory;
+        this.retries = retries;
     }
 
     public static Builder service(String serviceName) {
@@ -109,6 +112,10 @@ public final class Client {
     int readTimeoutMs() {
         return readTimeoutMs;
     }
+    
+    Retries retries() {
+        return retries;
+    }
 
     public Request url(String url) {
         Preconditions.checkNotNull(url);
@@ -155,6 +162,7 @@ public final class Client {
         private Clock clock = Clock.DEFAULT;
         private Environment environment = Environment.instance();
         private BaseUrlFactory baseUrlFactory = BaseUrlFactory.DEFAULT;
+        private Retries retries = new Retries();
         
         private Builder(String serviceName) {
             this.serviceName = serviceName;
@@ -295,7 +303,7 @@ public final class Client {
 
         public Client build() {
             return new Client(b.clock, b.serviceName, b.region, b.credentials, b.httpClient,
-                    b.connectTimeoutMs, b.readTimeoutMs, b.exceptionFactory, b.baseUrlFactory);
+                    b.connectTimeoutMs, b.readTimeoutMs, b.exceptionFactory, b.baseUrlFactory, b.retries);
         }
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -287,22 +287,26 @@ public final class Client {
         }
 
         public Builder4 retryInitialIntervalMs(long initialIntervalMs) {
-            b.retries.setInitialIntervalMs( initialIntervalMs);
+            Preconditions.checkArgument(initialIntervalMs >= 0);
+            b.retries = b.retries.withInitialIntervalMs( initialIntervalMs);
             return this;
         }
 
         public Builder4 retryMaxAttempts(int maxAttempts) {
-            b.retries.setMaxAttempts( maxAttempts);
+            Preconditions.checkArgument(maxAttempts >= 0);
+            b.retries = b.retries.withMaxAttempts( maxAttempts);
             return this;
         }
 
         public Builder4 retryBackoffFactor(double factor) {
-            b.retries.setBackoffFactor(factor);
+            Preconditions.checkArgument(factor >= 0);
+            b.retries = b.retries.withBackoffFactor(factor);
             return this;
         }
 
         public Builder4 retryMaxIntervalMs(long maxIntervalMs) {
-            b.retries.setMaxIntervalMs(maxIntervalMs);
+            Preconditions.checkArgument(maxIntervalMs >= 0);
+            b.retries = b.retries.withMaxIntervalMs(maxIntervalMs);
             return this;
         }
         

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -2,7 +2,6 @@ package com.github.davidmoten.aws.lw.client;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -287,25 +287,27 @@ public final class Client {
         }
 
         public Builder4 retryInitialInterval(long duration, TimeUnit unit) {
-            Preconditions.checkArgument(duration >= 0);
+            Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+            Preconditions.checkNotNull(unit, "unit cannot be null");
             b.retries = b.retries.withInitialIntervalMs(unit.toMillis(duration));
             return this;
         }
 
         public Builder4 retryMaxAttempts(int maxAttempts) {
-            Preconditions.checkArgument(maxAttempts >= 0);
+            Preconditions.checkArgument(maxAttempts >= 0, "maxAttempts cannot be negative");
             b.retries = b.retries.withMaxAttempts( maxAttempts);
             return this;
         }
 
         public Builder4 retryBackoffFactor(double factor) {
-            Preconditions.checkArgument(factor >= 0);
+            Preconditions.checkArgument(factor >= 0, "backoffFactor cannot be negative");
             b.retries = b.retries.withBackoffFactor(factor);
             return this;
         }
 
         public Builder4 retryMaxInterval(long duration, TimeUnit unit) {
-            Preconditions.checkArgument(duration >= 0);
+            Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+            Preconditions.checkNotNull(unit, "unit cannot be null");
             b.retries = b.retries.withMaxIntervalMs(unit.toMillis(duration));
             return this;
         }

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Client.java
@@ -271,25 +271,25 @@ public final class Client {
         }
 
         public Builder4 retryInitialIntervalMs(long initialIntervalMs) {
-            b.retries.initialIntervalMs = initialIntervalMs;
+            b.retries.setInitialIntervalMs( initialIntervalMs);
             return this;
         }
 
         public Builder4 retryMaxAttempts(int maxAttempts) {
-            b.retries.maxAttempts = maxAttempts;
+            b.retries.setMaxAttempts( maxAttempts);
             return this;
         }
 
         public Builder4 retryBackoffFactor(double factor) {
-            b.retries.backoffFactor = factor;
+            b.retries.setBackoffFactor(factor);
             return this;
         }
 
         public Builder4 retryMaxIntervalMs(long maxIntervalMs) {
-            b.retries.maxIntervalMs = maxIntervalMs;
+            b.retries.setMaxIntervalMs(maxIntervalMs);
             return this;
         }
-
+        
         public Builder4 connectTimeout(long duration, TimeUnit unit) {
             Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
             Preconditions.checkNotNull(unit, "unit cannot be null");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/MaxAttemptsExceededException.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/MaxAttemptsExceededException.java
@@ -1,6 +1,6 @@
 package com.github.davidmoten.aws.lw.client;
 
-public final class MaxAttemptsExceededException extends RuntimeException{
+public final class MaxAttemptsExceededException extends RuntimeException {
 
     /**
      * 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
@@ -80,7 +80,7 @@ public final class Multipart {
         }
 
         public Builder3 partTimeout(long duration, TimeUnit unit) {
-            Preconditions.checkArgument(duration > 0);
+            Preconditions.checkArgument(duration > 0, "duration must be positive");
             Preconditions.checkNotNull(unit, "unit cannot be null");
             b.timeoutMs = unit.toMillis(duration);
             return this;
@@ -97,26 +97,28 @@ public final class Multipart {
         }
 
         public Builder3 maxAttemptsPerAction(int maxAttempts) {
-            Preconditions.checkArgument(maxAttempts >= 1);
+            Preconditions.checkArgument(maxAttempts >= 1, "maxAttempts must be at least one");
             b.retries = b.retries.withMaxAttempts(maxAttempts);
             return this;
         }
 
-        public Builder3 retryIntervalMs(long retryIntervalMs) {
-            Preconditions.checkArgument(retryIntervalMs >= 0);
-            b.retries = b.retries.withInitialIntervalMs(retryIntervalMs);
+        public Builder3 retryInitialInterval(long duration, TimeUnit unit) {
+            Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+            Preconditions.checkNotNull(unit, "unit cannot be null");
+            b.retries = b.retries.withInitialIntervalMs(unit.toMillis(duration));
             return this;
         }
 
         public Builder3 retryBackoffFactor(double factor) {
-            Preconditions.checkArgument(factor >= 0);
+            Preconditions.checkArgument(factor >= 0, "retryBackoffFactory cannot be negative");
             b.retries = b.retries.withBackoffFactor(factor);
             return this;
         }
 
-        public Builder3 retryMaxIntervalMs(long retryMaxIntervalMs) {
-            Preconditions.checkArgument(retryMaxIntervalMs >= 0);
-            b.retries = b.retries.withMaxIntervalMs(retryMaxIntervalMs);
+        public Builder3 retryMaxInterval(long duration, TimeUnit unit) {
+            Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+            Preconditions.checkNotNull(unit, "unit cannot be null");
+            b.retries = b.retries.withMaxIntervalMs(unit.toMillis(duration));
             return this;
         }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
@@ -40,7 +40,7 @@ public final class Multipart {
 
         Builder(Client s3) {
             this.s3 = s3;
-            this.retries = s3.retries().withValueShouldRetry(ris -> false);
+            this.retries = s3.retries().withValueShouldRetry(values -> false);
         }
 
         public Builder2 bucket(String bucket) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
@@ -98,30 +98,29 @@ public final class Multipart {
 
         public Builder3 maxAttemptsPerAction(int maxAttempts) {
             Preconditions.checkArgument(maxAttempts >= 1);
-            b.retries.setMaxAttempts(maxAttempts);
+            b.retries = b.retries.withMaxAttempts(maxAttempts);
             return this;
         }
 
         public Builder3 retryIntervalMs(long retryIntervalMs) {
             Preconditions.checkArgument(retryIntervalMs >= 0);
-            b.retries.setInitialIntervalMs(retryIntervalMs);
-            return this;
-        }
-        
-        public Builder3 retryBackoffFactor(double factor) {
-            Preconditions.checkArgument(factor >= 0);
-            b.retries.setBackoffFactor(factor);
-            return this;
-        }
-        
-        public Builder3 retryMaxIntervalMs(long retryMaxIntervalMs) {
-            Preconditions.checkArgument(retryMaxIntervalMs >= 0);
-            b.retries.setMaxIntervalMs(retryMaxIntervalMs);
+            b.retries = b.retries.withInitialIntervalMs(retryIntervalMs);
             return this;
         }
 
-        public Builder3 transformCreateRequest(
-                Function<? super Request, ? extends Request> transform) {
+        public Builder3 retryBackoffFactor(double factor) {
+            Preconditions.checkArgument(factor >= 0);
+            b.retries = b.retries.withBackoffFactor(factor);
+            return this;
+        }
+
+        public Builder3 retryMaxIntervalMs(long retryMaxIntervalMs) {
+            Preconditions.checkArgument(retryMaxIntervalMs >= 0);
+            b.retries = b.retries.withMaxIntervalMs(retryMaxIntervalMs);
+            return this;
+        }
+
+        public Builder3 transformCreateRequest(Function<? super Request, ? extends Request> transform) {
             Preconditions.checkNotNull(transform, "transform cannot be null");
             b.transform = transform;
             return this;
@@ -160,8 +159,8 @@ public final class Multipart {
             if (b.executor == null) {
                 b.executor = Executors.newCachedThreadPool();
             }
-            return new MultipartOutputStream(b.s3, b.bucket, b.key, b.transform, b.executor,
-                    b.timeoutMs, b.retries, b.partSize);
+            return new MultipartOutputStream(b.s3, b.bucket, b.key, b.transform, b.executor, b.timeoutMs, b.retries,
+                    b.partSize);
         }
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Multipart.java
@@ -121,6 +121,22 @@ public final class Multipart {
             b.retries = b.retries.withMaxIntervalMs(unit.toMillis(duration));
             return this;
         }
+        
+        /**
+         * Sets the level of randomness applied to the next retry interval. The next
+         * calculated retry interval is multiplied by
+         * {@code (1 - jitter * Math.random())}. A value of zero means no jitter, 1
+         * means max jitter.
+         * 
+         * @param jitter level of randomness applied to the retry interval
+         * @return this
+         */
+        public Builder3 retryJitter(double jitter) {
+            Preconditions.checkArgument(jitter >= 0 && jitter <= 1, "jitter must be between 0 and 1");
+            b.retries = b.retries.withJitter(jitter);
+            return this;
+        }
+
 
         public Builder3 transformCreateRequest(Function<? super Request, ? extends Request> transform) {
             Preconditions.checkNotNull(transform, "transform cannot be null");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -120,34 +120,42 @@ public final class Request {
     }
 
     public Request connectTimeout(long duration, TimeUnit unit) {
-        Preconditions.checkArgument(duration >= 0);
+        Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+        Preconditions.checkNotNull(unit, "unit cannot be null");
         this.connectTimeoutMs = (int) unit.toMillis(duration);
         return this;
     }
 
     public Request readTimeout(long duration, TimeUnit unit) {
-        Preconditions.checkArgument(duration >= 0);
+        Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+        Preconditions.checkNotNull(unit, "unit cannot be null");
         this.readTimeoutMs = (int) unit.toMillis(duration);
         return this;
     }
 
-    public Request retryInitialIntervalMs(long initialIntervalMs) {
-        retries = retries.withInitialIntervalMs(initialIntervalMs);
+    public Request retryInitialInterval(long duration, TimeUnit unit) {
+        Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+        Preconditions.checkNotNull(unit, "unit cannot be null");
+        retries = retries.withInitialIntervalMs(unit.toMillis(duration));
         return this;
     }
 
     public Request retryMaxAttempts(int maxAttempts) {
+        Preconditions.checkArgument(maxAttempts >=0, "retryMaxAttempts cannot be negative");
         retries = retries.withMaxAttempts(maxAttempts);
         return this;
     }
 
     public Request retryBackoffFactor(double factor) {
+        Preconditions.checkArgument(factor >=0, "retryBackoffFactor cannot be negative");
         retries = retries.withBackoffFactor(factor);
         return this;
     }
 
-    public Request retryMaxIntervalMs(long maxIntervalMs) {
-        retries = retries.withMaxIntervalMs(maxIntervalMs);
+    public Request retryMaxInterval(long duration, TimeUnit unit) {
+        Preconditions.checkArgument(duration >= 0, "duration cannot be negative");
+        Preconditions.checkNotNull(unit, "unit cannot be null");
+        retries = retries.withMaxIntervalMs(unit.toMillis(duration));
         return this;
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -132,22 +132,22 @@ public final class Request {
     }
 
     public Request retryInitialIntervalMs(long initialIntervalMs) {
-        retries.initialIntervalMs = initialIntervalMs;
+        retries.setInitialIntervalMs(initialIntervalMs);
         return this;
     }
 
     public Request retryMaxAttempts(int maxAttempts) {
-        retries.maxAttempts = maxAttempts;
+        retries.setMaxAttempts(maxAttempts);
         return this;
     }
 
     public Request retryBackoffFactor(double factor) {
-        retries.backoffFactor = factor;
+        retries.setBackoffFactor(factor);
         return this;
     }
 
     public Request retryMaxIntervalMs(long maxIntervalMs) {
-        retries.maxIntervalMs = maxIntervalMs;
+        retries.setMaxIntervalMs(maxIntervalMs);
         return this;
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -26,7 +26,7 @@ public final class Request {
     private int connectTimeoutMs;
     private int readTimeoutMs;
     private int attributeNumber = 1;
-    private final Retries<ResponseInputStream> retries;
+    private Retries<ResponseInputStream> retries;
     private String attributePrefix = "Attribute";
     private String[] pathSegments;
     private final List<NameValue> queries = new ArrayList<>();
@@ -132,22 +132,22 @@ public final class Request {
     }
 
     public Request retryInitialIntervalMs(long initialIntervalMs) {
-        retries.setInitialIntervalMs(initialIntervalMs);
+        retries = retries.withInitialIntervalMs(initialIntervalMs);
         return this;
     }
 
     public Request retryMaxAttempts(int maxAttempts) {
-        retries.setMaxAttempts(maxAttempts);
+        retries = retries.withMaxAttempts(maxAttempts);
         return this;
     }
 
     public Request retryBackoffFactor(double factor) {
-        retries.setBackoffFactor(factor);
+        retries = retries.withBackoffFactor(factor);
         return this;
     }
 
     public Request retryMaxIntervalMs(long maxIntervalMs) {
-        retries.setMaxIntervalMs(maxIntervalMs);
+        retries = retries.withMaxIntervalMs(maxIntervalMs);
         return this;
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -141,15 +141,13 @@ public final class Request {
      *         finished with it
      */
     public ResponseInputStream responseInputStream() {
-        String u = calculateUrl(url, client.serviceName(), region, queries,
-                Arrays.asList(pathSegments), client.baseUrlFactory());
-        try {
-            return RequestHelper.request(client.clock(), client.httpClient(), u, method,
-                    RequestHelper.combineHeaders(headers), requestBody, client.serviceName(),
-                    region, client.credentials(), connectTimeoutMs, readTimeoutMs, signPayload);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        String u = calculateUrl(url, client.serviceName(), region, queries, Arrays.asList(pathSegments),
+                client.baseUrlFactory());
+        return client //
+                .retries() //
+                .call(() -> RequestHelper.request(client.clock(), client.httpClient(), u, method,
+                        RequestHelper.combineHeaders(headers), requestBody, client.serviceName(), region,
+                        client.credentials(), connectTimeoutMs, readTimeoutMs, signPayload));
     }
 
     /**

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -26,7 +26,7 @@ public final class Request {
     private int connectTimeoutMs;
     private int readTimeoutMs;
     private int attributeNumber = 1;
-    private final Retries retries;
+    private final Retries<ResponseInputStream> retries;
     private String attributePrefix = "Attribute";
     private String[] pathSegments;
     private final List<NameValue> queries = new ArrayList<>();
@@ -130,22 +130,22 @@ public final class Request {
         this.readTimeoutMs = (int) unit.toMillis(duration);
         return this;
     }
-    
+
     public Request retryInitialIntervalMs(long initialIntervalMs) {
         retries.initialIntervalMs = initialIntervalMs;
         return this;
     }
-    
+
     public Request retryMaxAttempts(int maxAttempts) {
         retries.maxAttempts = maxAttempts;
         return this;
     }
-    
+
     public Request retryBackoffFactor(double factor) {
         retries.backoffFactor = factor;
         return this;
     }
-    
+
     public Request retryMaxIntervalMs(long maxIntervalMs) {
         retries.maxIntervalMs = maxIntervalMs;
         return this;
@@ -213,11 +213,11 @@ public final class Request {
                 || r.header("Transfer-Encoding").orElse("").equalsIgnoreCase("chunked");
     }
 
-    private static String calculateUrl(String url, String serviceName, Optional<String> region,
-            List<NameValue> queries, List<String> pathSegments, BaseUrlFactory baseUrlFactory) {
+    private static String calculateUrl(String url, String serviceName, Optional<String> region, List<NameValue> queries,
+            List<String> pathSegments, BaseUrlFactory baseUrlFactory) {
         String u = url;
         if (u == null) {
-            String baseUrl = baseUrlFactory.create(serviceName,  region);
+            String baseUrl = baseUrlFactory.create(serviceName, region);
             Preconditions.checkNotNull(baseUrl, "baseUrl cannot be null");
             u = trimAndEnsureHasTrailingSlash(baseUrl) //
                     + pathSegments //
@@ -242,7 +242,7 @@ public final class Request {
         return u;
     }
 
-    //VisibleForTesting
+    // VisibleForTesting
     static String trimAndEnsureHasTrailingSlash(String s) {
         String r = s.trim();
         if (r.endsWith("/")) {
@@ -287,11 +287,10 @@ public final class Request {
     }
 
     public String presignedUrl(long expiryDuration, TimeUnit unit) {
-        String u = calculateUrl(url, client.serviceName(), region, queries,
-                Arrays.asList(pathSegments), client.baseUrlFactory());
-        return RequestHelper.presignedUrl(client.clock(), u, method.toString(),
-                RequestHelper.combineHeaders(headers), requestBody, client.serviceName(), region,
-                client.credentials(), connectTimeoutMs, readTimeoutMs,
+        String u = calculateUrl(url, client.serviceName(), region, queries, Arrays.asList(pathSegments),
+                client.baseUrlFactory());
+        return RequestHelper.presignedUrl(client.clock(), u, method.toString(), RequestHelper.combineHeaders(headers),
+                requestBody, client.serviceName(), region, client.credentials(), connectTimeoutMs, readTimeoutMs,
                 unit.toSeconds(expiryDuration), signPayload);
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -1,7 +1,5 @@
 package com.github.davidmoten.aws.lw.client;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -145,6 +145,22 @@ public final class Request {
         retries = retries.withMaxAttempts(maxAttempts);
         return this;
     }
+    
+    /**
+     * Sets the level of randomness applied to the next retry interval. The next
+     * calculated retry interval is multiplied by
+     * {@code (1 - jitter * Math.random())}. A value of zero means no jitter, 1
+     * means max jitter.
+     * 
+     * @param jitter level of randomness applied to the retry interval
+     * @return this
+     */
+    public Request retryJitter(double jitter) {
+        Preconditions.checkArgument(jitter >= 0 && jitter <= 1, "jitter must be between 0 and 1");
+        retries = retries.withJitter(jitter);
+        return this;
+    }
+
 
     public Request retryBackoffFactor(double factor) {
         Preconditions.checkArgument(factor >=0, "retryBackoffFactor cannot be negative");

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -129,7 +129,8 @@ public final class Retries<T> {
                 throwableShouldRetry);
     }
 
-    private static void rethrow(Throwable t) throws Error {
+    // VisibleForTesting
+    static void rethrow(Throwable t) throws Error {
         if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
         } else if (t instanceof Error) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -33,11 +33,11 @@ public final class Retries<T> {
     public static <T> Retries<T> create(Predicate<? super T> valueShouldRetry,
             Predicate<? super Throwable> throwableShouldRetry) {
         return new Retries<T>( //
-                500, //
-                10, //
+                100, //
+                4, //
                 2.0, //
                 0.0, // no jitter
-                30000, //
+                20000, //
                 valueShouldRetry, //
                 throwableShouldRetry);
     }

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -17,10 +17,10 @@ public final class Retries {
     private static final Set<Integer> throttlingStatusCodes = new HashSet<>( //
             Arrays.asList(400, 403, 429, 502, 503, 509));
 
-    public long initialIntervalMs = 500;
-    public int maxAttempts = 1;
+    public long initialIntervalMs = 100;
+    public int maxAttempts = 10;
     public double backoffFactor = 2.0;
-    public long maxIntervalMs = 32000;
+    public long maxIntervalMs = 30000;
     public Predicate<ResponseInputStream> statusCodeShouldRetry = ris -> transientStatusCodes.contains(ris.statusCode())
             || throttlingStatusCodes.contains(ris.statusCode());
     public Predicate<Throwable> throwableShouldRetry = t -> false;
@@ -38,7 +38,7 @@ public final class Retries {
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
                     return ris;
                 }
-                intervalMs = Math.max(maxIntervalMs, Math.round(backoffFactor * intervalMs));
+                intervalMs = Math.min(maxIntervalMs, Math.round(backoffFactor * intervalMs));
                 Thread.sleep(intervalMs);
             } catch (Throwable t) {
                 if (!throwableShouldRetry.test(t)) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -31,11 +31,11 @@ public final class Retries {
         while (true) {
             ResponseInputStream ris;
             try {
+                attempt++;
                 ris = callable.call();
                 if (!statusCodeShouldRetry.test(ris)) {
                     return ris;
                 }
-                attempt++;
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
                     return ris;
                 }
@@ -43,7 +43,6 @@ public final class Retries {
                 if (!throwableShouldRetry.test(t)) {
                     rethrow(t);
                 }
-                attempt++;
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
                     rethrow(t);
                 }

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -1,0 +1,58 @@
+package com.github.davidmoten.aws.lw.client.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.Predicate;
+
+import com.github.davidmoten.aws.lw.client.ResponseInputStream;
+
+public final class Retries {
+
+    private static final Set<Integer> transientStatusCodes = new HashSet<>(Arrays.asList(400, 408, 500, 502, 503, 509));
+    private static final Set<Integer> throttlingStatusCodes = new HashSet<>(
+            Arrays.asList(400, 403, 429, 502, 503, 509));
+
+    public long initialIntervalMs = 500;
+    public int maxAttempts = 1;
+    public double backoffFactor = 2.0;
+    public long maxIntervalMs = 32000;
+    public Predicate<ResponseInputStream> statusCodeShouldRetry = ris -> transientStatusCodes.contains(ris.statusCode())
+            || throttlingStatusCodes.contains(ris.statusCode());
+    public Predicate<Throwable> throwableShouldRetry = t -> false;
+
+    public ResponseInputStream call(Callable<ResponseInputStream> callable) {
+        long intervalMs = initialIntervalMs;
+        int attempt = 0;
+        while (true) {
+            try {
+                ResponseInputStream ris = callable.call();
+                if (!statusCodeShouldRetry.test(ris)) {
+                    return ris;
+                }
+                attempt++;
+                if (maxAttempts > 0 && attempt >= maxAttempts) {
+                    return ris;
+                }
+                intervalMs = Math.max(maxIntervalMs, Math.round(backoffFactor * intervalMs));
+                Thread.sleep(intervalMs);
+            } catch (Throwable t) {
+                if (!throwableShouldRetry.test(t)) {
+                    if (t instanceof RuntimeException) {
+                        throw (RuntimeException) t;
+                    } else if (t instanceof Error) {
+                        throw (Error) t;
+                    } else if (t instanceof IOException) {
+                        throw new UncheckedIOException((IOException) t);
+                    } else {
+                        throw new RuntimeException(t);
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -12,8 +12,9 @@ import com.github.davidmoten.aws.lw.client.ResponseInputStream;
 
 public final class Retries {
 
-    private static final Set<Integer> transientStatusCodes = new HashSet<>(Arrays.asList(400, 408, 500, 502, 503, 509));
-    private static final Set<Integer> throttlingStatusCodes = new HashSet<>(
+    private static final Set<Integer> transientStatusCodes = new HashSet<>( //
+            Arrays.asList(400, 408, 500, 502, 503, 509));
+    private static final Set<Integer> throttlingStatusCodes = new HashSet<>( //
             Arrays.asList(400, 403, 429, 502, 503, 509));
 
     public long initialIntervalMs = 500;

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -70,13 +70,14 @@ public final class Retries<T> {
                     throw new MaxAttemptsExceededException("exceeded max attempts " + maxAttempts, t);
                 }
             }
+            sleep(intervalMs);
+            //calculate the interval for the next retry
             intervalMs = Math.round(backoffFactor * intervalMs);
             if (maxIntervalMs > 0) {
                 intervalMs = Math.min(maxIntervalMs, intervalMs);
             }
             // apply jitter (if 0 then no change)
             intervalMs = Math.round((1 - jitter * Math.random()) * intervalMs);
-            sleep(intervalMs);
         }
     }
 

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -83,16 +83,15 @@ public final class Retries<T> {
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
                     throw new MaxAttemptsExceededException("exceeded max attempts " + maxAttempts, t);
                 }
-            } finally {
-                intervalMs = Math.round(backoffFactor * intervalMs);
-                if (maxIntervalMs > 0) {
-                    intervalMs = Math.min(maxIntervalMs, intervalMs);
-                }
-                try {
-                    Thread.sleep(intervalMs);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+            } 
+            intervalMs = Math.round(backoffFactor * intervalMs);
+            if (maxIntervalMs > 0) {
+                intervalMs = Math.min(maxIntervalMs, intervalMs);
+            }
+            try {
+                Thread.sleep(intervalMs);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -57,7 +57,7 @@ public final class Retries<T> {
                 if (!valueShouldRetry.test(value)) {
                     return value;
                 }
-                if (maxAttempts > 0 && attempt >= maxAttempts) {
+                if (reachedMaxAttempts(attempt, maxAttempts)) {
                     // note that caller is not aware that maxAttempts were reached, the caller just
                     // receives the last error response
                     return value;
@@ -66,7 +66,7 @@ public final class Retries<T> {
                 if (!throwableShouldRetry.test(t)) {
                     rethrow(t);
                 }
-                if (maxAttempts > 0 && attempt >= maxAttempts) {
+                if (reachedMaxAttempts(attempt, maxAttempts)) {
                     throw new MaxAttemptsExceededException("exceeded max attempts " + maxAttempts, t);
                 }
             }
@@ -79,6 +79,11 @@ public final class Retries<T> {
             // apply jitter (if 0 then no change)
             intervalMs = Math.round((1 - jitter * Math.random()) * intervalMs);
         }
+    }
+
+    // VisibleForTesting
+    static boolean reachedMaxAttempts(int attempt, int maxAttempts) {
+        return maxAttempts > 0 && attempt >= maxAttempts;
     }
 
     static void sleep(long intervalMs) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -12,7 +12,7 @@ import com.github.davidmoten.aws.lw.client.MaxAttemptsExceededException;
 import com.github.davidmoten.aws.lw.client.ResponseInputStream;
 
 public final class Retries<T> {
-    
+
     // from
     // https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html
     private static final Set<Integer> transientStatusCodes = new HashSet<>( //
@@ -59,7 +59,7 @@ public final class Retries<T> {
     public T call(Callable<T> callable) {
         return call(callable, valueShouldRetry);
     }
-    
+
     public <S> S call(Callable<S> callable, Predicate<? super S> valueShouldRetry) {
         long intervalMs = initialIntervalMs;
         int attempt = 0;
@@ -72,6 +72,8 @@ public final class Retries<T> {
                     return value;
                 }
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
+                    // note that caller is not aware that maxAttempts were reached, the caller just
+                    // receives the last error response
                     return value;
                 }
             } catch (Throwable t) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -11,7 +11,7 @@ import java.util.function.Predicate;
 import com.github.davidmoten.aws.lw.client.MaxAttemptsExceededException;
 import com.github.davidmoten.aws.lw.client.ResponseInputStream;
 
-public final class Retries {
+public final class Retries<T> {
 
     private static final Set<Integer> transientStatusCodes = new HashSet<>( //
             Arrays.asList(400, 408, 500, 502, 503, 509));
@@ -22,11 +22,11 @@ public final class Retries {
     public int maxAttempts = 10;
     public double backoffFactor = 2.0;
     public long maxIntervalMs = 30000;
-    public Predicate<ResponseInputStream> statusCodeShouldRetry;
+    public Predicate<T> valueShouldRetry;
     public Predicate<Throwable> throwableShouldRetry;
 
-    public Retries() {
-        this( //
+    public static Retries<ResponseInputStream> requestRetries() {
+        return new Retries<>( //
                 500, //
                 10, //
                 2.0, //
@@ -37,33 +37,33 @@ public final class Retries {
     }
 
     public Retries(long initialIntervalMs, int maxAttempts, double backoffFactor, long maxIntervalMs,
-            Predicate<ResponseInputStream> statusCodeShouldRetry, Predicate<Throwable> throwableShouldRetry) {
+            Predicate<T> valueShouldRetry, Predicate<Throwable> throwableShouldRetry) {
         this.initialIntervalMs = initialIntervalMs;
         this.maxAttempts = maxAttempts;
         this.backoffFactor = backoffFactor;
         this.maxIntervalMs = maxIntervalMs;
-        this.statusCodeShouldRetry = statusCodeShouldRetry;
+        this.valueShouldRetry = valueShouldRetry;
         this.throwableShouldRetry = throwableShouldRetry;
     }
 
-    public Retries copy() {
-        return new Retries(initialIntervalMs, maxAttempts, backoffFactor, maxIntervalMs, statusCodeShouldRetry,
+    public Retries<T> copy() {
+        return new Retries<>(initialIntervalMs, maxAttempts, backoffFactor, maxIntervalMs, valueShouldRetry,
                 throwableShouldRetry);
     }
 
-    public ResponseInputStream call(Callable<ResponseInputStream> callable) {
+    public T call(Callable<T> callable) {
         long intervalMs = initialIntervalMs;
         int attempt = 0;
         while (true) {
-            ResponseInputStream ris;
+            T value;
             try {
                 attempt++;
-                ris = callable.call();
-                if (!statusCodeShouldRetry.test(ris)) {
-                    return ris;
+                value = callable.call();
+                if (!valueShouldRetry.test(value)) {
+                    return value;
                 }
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
-                    return ris;
+                    return value;
                 }
             } catch (Throwable t) {
                 if (!throwableShouldRetry.test(t)) {
@@ -83,7 +83,7 @@ public final class Retries {
         }
     }
 
-    private void rethrow(Throwable t) throws Error {
+    private static void rethrow(Throwable t) throws Error {
         if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
         } else if (t instanceof Error) {

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -113,6 +113,11 @@ public final class Retries<T> {
         return new Retries<T>(initialIntervalMs, maxAttempts, backoffFactor, jitter, maxIntervalMs, valueShouldRetry,
                 throwableShouldRetry);
     }
+    
+    public Retries<T> withJitter(double jitter) {
+        return new Retries<T>(initialIntervalMs, maxAttempts, backoffFactor, jitter, maxIntervalMs, valueShouldRetry,
+                throwableShouldRetry);
+    }
 
     public Retries<T> withThrowableShouldRetry(Predicate<? super Throwable> throwableShouldRetry) {
         return new Retries<T>(initialIntervalMs, maxAttempts, backoffFactor, jitter, maxIntervalMs, valueShouldRetry,

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/Retries.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 
+import com.github.davidmoten.aws.lw.client.MaxAttemptsExceededException;
 import com.github.davidmoten.aws.lw.client.ResponseInputStream;
 
 public final class Retries {
@@ -44,7 +45,8 @@ public final class Retries {
                     rethrow(t);
                 }
                 if (maxAttempts > 0 && attempt >= maxAttempts) {
-                    rethrow(t);
+                    throw new MaxAttemptsExceededException(
+                            "exceeded max attempts " + maxAttempts, t);
                 }
             } finally {
                 intervalMs = Math.min(maxIntervalMs, Math.round(backoffFactor * intervalMs));

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -351,6 +351,7 @@ public class ClientTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
+                .maxAttempts(1) //
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -390,6 +391,7 @@ public class ClientTest {
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
                 .exception(r -> !r.isOk(), r -> new UnsupportedOperationException()) //
+                .maxAttempts(1)
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -414,6 +416,7 @@ public class ClientTest {
                 .clock(() -> 1622695846902L) //
                 .exception(r -> !r.isOk() && r.statusCode() == 404,
                         r -> new UnsupportedOperationException()) //
+                .maxAttempts(1) //
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -443,6 +446,7 @@ public class ClientTest {
                         return Optional.of(new UnsupportedOperationException());
                     }
                 }) //
+                .maxAttempts(1) //
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -798,6 +798,7 @@ public class ClientTest {
                 .clock(() -> 1622695846902L) //
                 .retryInitialInterval(100, TimeUnit.MILLISECONDS) //
                 .retryMaxAttempts(2) //
+                .retryStatusCodes(408) //
                 .build();
         try (Server server = Server.start()) {
             server.response().statusCode(408).body("timed out").add();
@@ -852,7 +853,7 @@ public class ClientTest {
                 .retryBackoffFactor(2.0) //
                 .retryMaxInterval(3, TimeUnit.SECONDS) //
                 .retryJitter(0) //
-                .retryStatusCodes(200) //
+                .retryStatusCodes(400) //
                 .httpClient(hc) //
                 .build();
         try {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -678,7 +678,7 @@ public class ClientTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
-                .retryInitialIntervalMs(100) //
+                .retryInitialInterval(100, TimeUnit.MILLISECONDS) //
                 .build();
         try (Server server = Server.start()) {
             server.response().statusCode(408).body("timed out").add();
@@ -700,7 +700,7 @@ public class ClientTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
-                .retryInitialIntervalMs(100) //
+                .retryInitialInterval(100, TimeUnit.MILLISECONDS) //
                 .retryMaxAttempts(2) //
                 .build();
         try (Server server = Server.start()) {
@@ -728,7 +728,7 @@ public class ClientTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
-                .retryInitialIntervalMs(100) //
+                .retryInitialInterval(100, TimeUnit.MILLISECONDS) //
                 .retryMaxAttempts(10) //
                 .httpClient(hc) //
                 .build();
@@ -751,8 +751,10 @@ public class ClientTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
-                .retryInitialIntervalMs(100) //
+                .retryInitialInterval(100, TimeUnit.MILLISECONDS) //
                 .retryMaxAttempts(2) //
+                .retryBackoffFactor(2.0) //
+                .retryMaxInterval(3, TimeUnit.SECONDS) //
                 .httpClient(hc) //
                 .build();
         try {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -220,7 +220,7 @@ public class ClientTest {
         assertEquals(6000, hc.readTimeoutMs);
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test(expected = MaxAttemptsExceededException.class)
     public void testThrows() {
         Client client = Client //
                 .s3() //
@@ -650,7 +650,7 @@ public class ClientTest {
         assertEquals(a.size(), hc.headers.size());
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test(expected = MaxAttemptsExceededException.class)
     public void testUrlDoesNotExist() {
         Client s3 = Client.s3().region("ap-southeast-2").accessKey("123").secretKey("456").maxAttempts(1).build();
         s3.url("https://doesnotexist.z21894649.com").execute();

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -56,6 +56,10 @@ public class ClientTest {
                 .region("ap-southeast-2") //
                 .connectTimeout(5, TimeUnit.SECONDS) //
                 .readTimeout(6, TimeUnit.SECONDS) //
+                .retryMaxAttempts(1) //
+                .retryBackoffFactor(1.0) //
+                .retryInitialInterval(10, TimeUnit.MILLISECONDS) //
+                .retryMaxInterval(1, TimeUnit.SECONDS) //
                 .execute();
         assertEquals(
                 "https://s3.ap-southeast-2.amazonaws.com/MyBucket?type=thing&Attribute.1.Name=color&Attribute.1.Value=red&Attribute.2.Name=color&Attribute.2.Value=blue&Message.1.Name=name&Message.1.Value=hi&Message.2.Name=name&Message.2.Value=there",

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -756,6 +756,17 @@ public class ClientTest {
     }
     
     @Test(expected=IllegalArgumentException.class)
+    public void testTooLargeRetryJitter() {
+        Client //
+                .s3() //
+                .region("ap-southeast-2") //
+                .accessKey("123") //
+                .secretKey("456") //
+                .clock(() -> 1622695846902L) //
+                .retryJitter(2);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
     public void testNegativeRetryMaxAttempts() {
         Client //
                 .s3() //
@@ -841,6 +852,7 @@ public class ClientTest {
                 .retryBackoffFactor(2.0) //
                 .retryMaxInterval(3, TimeUnit.SECONDS) //
                 .retryJitter(0) //
+                .retryStatusCodes(200) //
                 .httpClient(hc) //
                 .build();
         try {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -230,7 +229,7 @@ public class ClientTest {
                 .connectTimeout(5, TimeUnit.SECONDS) //
                 .readTimeout(6, TimeUnit.SECONDS) //
                 .httpClient(HttpClientTesting.THROWING) //
-                .maxAttempts(1) //
+                .retryMaxAttempts(1) //
                 .build();
 
         // create a bucket
@@ -331,7 +330,7 @@ public class ClientTest {
                     .clock(() -> 1622695846902L) //
                     .connectTimeout(10, TimeUnit.SECONDS) //
                     .readTimeout(10, TimeUnit.SECONDS) //
-                    .maxAttempts(1) //
+                    .retryMaxAttempts(1) //
                     .build();
             try (Server server = Server.start()) {
                 server.response().body("<a>hello</a>").add();
@@ -353,7 +352,7 @@ public class ClientTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
-                .maxAttempts(1) //
+                .retryMaxAttempts(1) //
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -393,7 +392,7 @@ public class ClientTest {
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
                 .exception(r -> !r.isOk(), r -> new UnsupportedOperationException()) //
-                .maxAttempts(1)
+                .retryMaxAttempts(1)
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -418,7 +417,7 @@ public class ClientTest {
                 .clock(() -> 1622695846902L) //
                 .exception(r -> !r.isOk() && r.statusCode() == 404,
                         r -> new UnsupportedOperationException()) //
-                .maxAttempts(1) //
+                .retryMaxAttempts(1) //
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -448,7 +447,7 @@ public class ClientTest {
                         return Optional.of(new UnsupportedOperationException());
                     }
                 }) //
-                .maxAttempts(1) //
+                .retryMaxAttempts(1) //
                 .build();
         try (Server server = Server.start()) {
             server.response().body("hello").statusCode(500).add();
@@ -652,7 +651,7 @@ public class ClientTest {
 
     @Test(expected = MaxAttemptsExceededException.class)
     public void testUrlDoesNotExist() {
-        Client s3 = Client.s3().region("ap-southeast-2").accessKey("123").secretKey("456").maxAttempts(1).build();
+        Client s3 = Client.s3().region("ap-southeast-2").accessKey("123").secretKey("456").retryMaxAttempts(1).build();
         s3.url("https://doesnotexist.z21894649.com").execute();
     }
 

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -691,6 +691,39 @@ public class ClientTest {
             assertEquals("stuff", text);
         }
     }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNegativeRetryInitialInterval() {
+        Client //
+                .s3() //
+                .region("ap-southeast-2") //
+                .accessKey("123") //
+                .secretKey("456") //
+                .clock(() -> 1622695846902L) //
+                .retryInitialInterval(-1, TimeUnit.MILLISECONDS);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testNegativeRetryMaxInterval() {
+        Client //
+                .s3() //
+                .region("ap-southeast-2") //
+                .accessKey("123") //
+                .secretKey("456") //
+                .clock(() -> 1622695846902L) //
+                .retryMaxInterval(-1, TimeUnit.MILLISECONDS);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testNegativeRetryMaxAttempts() {
+        Client //
+                .s3() //
+                .region("ap-southeast-2") //
+                .accessKey("123") //
+                .secretKey("456") //
+                .clock(() -> 1622695846902L) //
+                .retryMaxAttempts(-1);
+    }
     
     @Test
     public void testRetriesFailTwiceThenHitMaxAttempts() {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -60,6 +60,7 @@ public class ClientTest {
                 .retryBackoffFactor(1.0) //
                 .retryInitialInterval(10, TimeUnit.MILLISECONDS) //
                 .retryMaxInterval(1, TimeUnit.SECONDS) //
+                .retryJitter(0) //
                 .execute();
         assertEquals(
                 "https://s3.ap-southeast-2.amazonaws.com/MyBucket?type=thing&Attribute.1.Name=color&Attribute.1.Value=red&Attribute.2.Name=color&Attribute.2.Value=blue&Message.1.Name=name&Message.1.Value=hi&Message.2.Name=name&Message.2.Value=there",
@@ -217,6 +218,11 @@ public class ClientTest {
     @Test(expected = IllegalArgumentException.class)
     public void testBadRetryMaxAttempts() {
         s3.path().retryMaxAttempts(-1);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadRetryJitter() {
+        s3.path().retryJitter(-1);
     }
     
     @Test(expected = IllegalArgumentException.class)
@@ -739,6 +745,17 @@ public class ClientTest {
     }
     
     @Test(expected=IllegalArgumentException.class)
+    public void testNegativeRetryJitter() {
+        Client //
+                .s3() //
+                .region("ap-southeast-2") //
+                .accessKey("123") //
+                .secretKey("456") //
+                .clock(() -> 1622695846902L) //
+                .retryJitter(-1);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
     public void testNegativeRetryMaxAttempts() {
         Client //
                 .s3() //
@@ -823,6 +840,7 @@ public class ClientTest {
                 .retryMaxAttempts(2) //
                 .retryBackoffFactor(2.0) //
                 .retryMaxInterval(3, TimeUnit.SECONDS) //
+                .retryJitter(0) //
                 .httpClient(hc) //
                 .build();
         try {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -827,7 +827,7 @@ public class ClientTest {
                 .secretKey("456") //
                 .clock(() -> 1622695846902L) //
                 .retryInitialInterval(100, TimeUnit.MILLISECONDS) //
-                .retryMaxAttempts(10) //
+                .retryMaxAttempts(0) //
                 .httpClient(hc) //
                 .build();
         String text = client //

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -725,6 +725,17 @@ public class ClientTest {
                 .retryMaxAttempts(-1);
     }
     
+    @Test(expected=IllegalArgumentException.class)
+    public void testNegativeRetryBackoffFactor() {
+        Client //
+                .s3() //
+                .region("ap-southeast-2") //
+                .accessKey("123") //
+                .secretKey("456") //
+                .clock(() -> 1622695846902L) //
+                .retryBackoffFactor(-1.0);
+    }
+    
     @Test
     public void testRetriesFailTwiceThenHitMaxAttempts() {
         Client client = Client //

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -207,7 +207,6 @@ public class ClientTest {
                 .readTimeout(6, TimeUnit.SECONDS) //
                 .httpClient(hc) //
                 .build();
-
         // create a bucket
         client //
                 .path("MyBucket") //

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -199,6 +199,26 @@ public class ClientTest {
     public void testBadReadTimeout2() {
         s3.path().readTimeout(-1, TimeUnit.SECONDS);
     }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadRetryInitialInterval() {
+        s3.path().retryInitialInterval(-1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadRetryMaxInterval() {
+        s3.path().retryMaxInterval(-1, TimeUnit.SECONDS);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadRetryMaxAttempts() {
+        s3.path().retryMaxAttempts(-1);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadRetryBackoffFactor() {
+        s3.path().retryBackoffFactor(-1);
+    }
 
     @Test
     public void testTimeoutsAtClientLevel() {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -230,6 +230,7 @@ public class ClientTest {
                 .connectTimeout(5, TimeUnit.SECONDS) //
                 .readTimeout(6, TimeUnit.SECONDS) //
                 .httpClient(HttpClientTesting.THROWING) //
+                .maxAttempts(1) //
                 .build();
 
         // create a bucket
@@ -321,7 +322,7 @@ public class ClientTest {
 
     @Test
     public void testServerOkResponse2() throws InterruptedException {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 10; i++) {
             Client client = Client //
                     .s3() //
                     .region("ap-southeast-2") //
@@ -330,6 +331,7 @@ public class ClientTest {
                     .clock(() -> 1622695846902L) //
                     .connectTimeout(10, TimeUnit.SECONDS) //
                     .readTimeout(10, TimeUnit.SECONDS) //
+                    .maxAttempts(1) //
                     .build();
             try (Server server = Server.start()) {
                 server.response().body("<a>hello</a>").add();
@@ -650,7 +652,7 @@ public class ClientTest {
 
     @Test(expected = UncheckedIOException.class)
     public void testUrlDoesNotExist() {
-        Client s3 = Client.s3().region("ap-southeast-2").accessKey("123").secretKey("456").build();
+        Client s3 = Client.s3().region("ap-southeast-2").accessKey("123").secretKey("456").maxAttempts(1).build();
         s3.url("https://doesnotexist.z21894649.com").execute();
     }
 

--- a/src/test/java/com/github/davidmoten/aws/lw/client/HttpClientTestingWithQueue.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/HttpClientTestingWithQueue.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-public class HttpClientTesting2 implements HttpClient {
+public class HttpClientTestingWithQueue implements HttpClient {
 
     // needs to be volatile to work with Multipart async operations
     private final Queue<ResponseInputStream> queue = new LinkedList<>();

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -302,21 +302,21 @@ public class MultipartTest {
     @Test(expected = IllegalArgumentException.class)
     public void testMultipartOutputStreamBadArgumentPartTimeoutMs() {
         new MultipartOutputStream(s3(), "bucket", "key", x -> x, Executors.newFixedThreadPool(1),
-                -1, Retries.retries(x -> false, x -> true), 0);
+                -1, Retries.create(x -> false, x -> true), 0);
     }
 
     @SuppressWarnings("resource")
     @Test(expected = IllegalArgumentException.class)
     public void testMultipartOutputStreamBadArgumentMaxAttempts() {
         new MultipartOutputStream(s3(), "bucket", "key", x -> x, Executors.newFixedThreadPool(1), 1,
-                Retries.retries(x -> false, x -> true), 0);
+                Retries.create(x -> false, x -> true), 0);
     }
 
     @SuppressWarnings("resource")
     @Test(expected = IllegalArgumentException.class)
     public void testMultipartOutputStreamBadArgumentPartSize() {
         new MultipartOutputStream(s3(), "bucket", "key", x -> x, Executors.newFixedThreadPool(1), 1,
-                Retries.retries(x -> false, x -> true), 1000);
+                Retries.create(x -> false, x -> true), 1000);
     }
 
     @Test

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -274,6 +274,7 @@ public class MultipartTest {
                 .retryInitialInterval(1, TimeUnit.SECONDS) //
                 .retryBackoffFactor(1.0) //
                 .retryMaxInterval(10, TimeUnit.SECONDS) //
+                .retryJitter(0) //
                 .outputStream()) {
             for (int i = 0; i < 600000; i++) {
                 out.write("0123456789".getBytes(StandardCharsets.UTF_8));
@@ -372,6 +373,15 @@ public class MultipartTest {
                 .key("mykey") //
                 .retryMaxInterval(-1, TimeUnit.SECONDS);
     }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipartBadRetryJitter() {
+        Multipart.s3(s3()) //
+                .bucket("mybucket") //
+                .key("mykey") //
+                .retryJitter(-1);
+    }
+
 
     @Test
     public void isUtilityClass() {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -348,6 +348,30 @@ public class MultipartTest {
                 .key("mykey") //
                 .partTimeout(-1, TimeUnit.MINUTES);
     }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipartBadRetryInitialInterval() {
+        Multipart.s3(s3()) //
+                .bucket("mybucket") //
+                .key("mykey") //
+                .retryInitialInterval(-1, TimeUnit.MINUTES);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipartBadRetryBackoffFactor() {
+        Multipart.s3(s3()) //
+                .bucket("mybucket") //
+                .key("mykey") //
+                .retryBackoffFactor(-1);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipartBadRetryMaxInterval() {
+        Multipart.s3(s3()) //
+                .bucket("mybucket") //
+                .key("mykey") //
+                .retryMaxInterval(-1, TimeUnit.SECONDS);
+    }
 
     @Test
     public void isUtilityClass() {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -86,7 +86,8 @@ public class MultipartTest {
                 .partSizeMb(5) // s
                 .partTimeout(5, TimeUnit.MINUTES) //
                 .outputStream()) {
-            out.write(new byte[5 * 1024 * 1024]);
+            out.write(0);
+            out.write(new byte[5 * 1024 * 1024 - 1]);
         }
         assertEquals(Arrays.asList( //
                 "POST:https://s3.ap-southeast-2.amazonaws.com/mybucket/mykey?uploads",
@@ -381,7 +382,14 @@ public class MultipartTest {
                 .key("mykey") //
                 .retryJitter(-1);
     }
-
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipartBadRetryJitter2() {
+        Multipart.s3(s3()) //
+                .bucket("mybucket") //
+                .key("mykey") //
+                .retryJitter(2);
+    }
 
     @Test
     public void isUtilityClass() {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -273,7 +273,7 @@ public class MultipartTest {
                 .maxAttemptsPerAction(1) //
                 .retryInitialInterval(1, TimeUnit.SECONDS) //
                 .retryBackoffFactor(1.0) //
-                .retryMaxInterval(1, TimeUnit.SECONDS) //
+                .retryMaxInterval(10, TimeUnit.SECONDS) //
                 .outputStream()) {
             for (int i = 0; i < 600000; i++) {
                 out.write("0123456789".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -65,7 +65,7 @@ public class MultipartTest {
 
     @Test
     public void testMultipartSingleWriteOfExactlyPartsSize() throws Exception {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -96,7 +96,7 @@ public class MultipartTest {
     }
 
     public void testMultipart(Consumer<MultipartOutputStream> consumer) throws Exception {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -134,7 +134,7 @@ public class MultipartTest {
 
     @Test(expected = UncheckedIOException.class)
     public void testMultipartUploadFileDoesNotExist() throws IOException {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -155,7 +155,7 @@ public class MultipartTest {
 
     @Test(expected = RuntimeException.class)
     public void testMultipartUploadInputStreamFactoryThrows() throws IOException {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -177,7 +177,7 @@ public class MultipartTest {
 
     @Test
     public void testMultipartUploadFile() throws IOException {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -215,7 +215,7 @@ public class MultipartTest {
 
     @Test
     public void testMultipartUploadByteArray() throws IOException {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -251,7 +251,7 @@ public class MultipartTest {
 
     @Test
     public void testMultipartAbort() throws IOException {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //
@@ -321,7 +321,7 @@ public class MultipartTest {
 
     @Test
     public void testMultipartDefaultExecutor() {
-        HttpClientTesting2 h = new HttpClientTesting2();
+        HttpClientTestingWithQueue h = new HttpClientTestingWithQueue();
         Client s3 = Client //
                 .s3() //
                 .region("ap-southeast-2") //

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -257,6 +257,7 @@ public class MultipartTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .httpClient(h) //
+                .maxAttempts(1) //
                 .build();
 
         h.add(startMultipartUpload());
@@ -274,6 +275,7 @@ public class MultipartTest {
                 out.write("0123456789".getBytes(StandardCharsets.UTF_8));
             }
         } catch (RuntimeException e) {
+            e.printStackTrace();
             assertTrue(e.getCause().getCause() instanceof MaxAttemptsExceededException);
         }
 

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -81,7 +81,7 @@ public class MultipartTest {
                 .bucket("mybucket") //
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.MILLISECONDS) //
                 .transformCreateRequest(x -> x) //
                 .partSizeMb(5) // s
                 .partTimeout(5, TimeUnit.MINUTES) //
@@ -116,7 +116,7 @@ public class MultipartTest {
                 .bucket("mybucket") //
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.MILLISECONDS) //
                 .partSizeMb(5) //
                 .partTimeout(5, TimeUnit.MINUTES) //
                 .outputStream()) {
@@ -146,7 +146,7 @@ public class MultipartTest {
                 .bucket("mybucket") //
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.MILLISECONDS) //
                 .partSizeMb(5) //
                 .partTimeout(5, TimeUnit.MINUTES) //
                 .upload(new File("target/doesnotexist"));
@@ -167,7 +167,7 @@ public class MultipartTest {
                 .bucket("mybucket") //
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.MILLISECONDS) //
                 .partSizeMb(5) //
                 .partTimeout(5, TimeUnit.MINUTES) //
                 .upload(() -> {
@@ -198,7 +198,7 @@ public class MultipartTest {
                 .bucket("mybucket") //
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.MILLISECONDS) //
                 .partSizeMb(5) //
                 .partTimeout(5, TimeUnit.MINUTES) //
                 .upload(file);
@@ -234,7 +234,7 @@ public class MultipartTest {
                 .bucket("mybucket") //
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.MILLISECONDS) //
                 .partSizeMb(5) //
                 .partTimeout(5, TimeUnit.MINUTES) //
                 .upload(bytes);
@@ -271,8 +271,9 @@ public class MultipartTest {
                 .key("mykey") //
                 .executor(Executors.newFixedThreadPool(1)) //
                 .maxAttemptsPerAction(1) //
-                .retryIntervalMs(1) //
+                .retryInitialInterval(1, TimeUnit.SECONDS) //
                 .retryBackoffFactor(1.0) //
+                .retryMaxInterval(1, TimeUnit.SECONDS) //
                 .outputStream()) {
             for (int i = 0; i < 600000; i++) {
                 out.write("0123456789".getBytes(StandardCharsets.UTF_8));
@@ -365,7 +366,7 @@ public class MultipartTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testMultipartBadArgument3() {
-        Multipart.s3(s3()).bucket("bucket").key("key").retryIntervalMs(-1);
+        Multipart.s3(s3()).bucket("bucket").key("key").retryInitialInterval(-1, TimeUnit.MILLISECONDS);
     }
 
     private static final Closeable DO_NOTHING = () -> {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/MultipartTest.java
@@ -257,7 +257,7 @@ public class MultipartTest {
                 .accessKey("123") //
                 .secretKey("456") //
                 .httpClient(h) //
-                .maxAttempts(1) //
+                .retryMaxAttempts(1) //
                 .build();
 
         h.add(startMultipartUpload());

--- a/src/test/java/com/github/davidmoten/aws/lw/client/internal/RetriesTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/internal/RetriesTest.java
@@ -1,5 +1,8 @@
 package com.github.davidmoten.aws.lw.client.internal;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
@@ -39,4 +42,24 @@ public class RetriesTest {
         Retries.rethrow(new Exception());
     }
 
+    @Test
+    public void testNotYetReachedMaxAttempts() {
+        assertFalse(Retries.reachedMaxAttempts(1, 2));
+    }
+    
+    @Test
+    public void testReachedMaxAttemptsExactly() {
+        assertTrue(Retries.reachedMaxAttempts(2, 2));
+    }
+    
+    @Test
+    public void testExceededMaxAttempts() {
+        assertTrue(Retries.reachedMaxAttempts(3, 2));
+    }
+    
+    @Test
+    public void testUnlimitedAtempts() {
+        assertFalse(Retries.reachedMaxAttempts(3, 0));
+    }
+    
 }

--- a/src/test/java/com/github/davidmoten/aws/lw/client/internal/RetriesTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/internal/RetriesTest.java
@@ -1,0 +1,42 @@
+package com.github.davidmoten.aws.lw.client.internal;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.junit.Test;
+
+public class RetriesTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadJitter() {
+        double jitter = -1;
+        new Retries<Void>(100, 10, 2.0, jitter, 30000, x -> false, x -> false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadJitter2() {
+        double jitter = 2;
+        new Retries<Void>(100, 10, 2.0, jitter, 30000, x -> false, x -> false);
+    }
+
+    @Test(expected = OutOfMemoryError.class)
+    public void testRethrowError() {
+        Retries.rethrow(new OutOfMemoryError());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testRethrowRuntimeError() {
+        Retries.rethrow(new NullPointerException());
+    }
+
+    @Test(expected = UncheckedIOException.class)
+    public void testRethrowIOException() {
+        Retries.rethrow(new IOException());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testRethrowException() {
+        Retries.rethrow(new Exception());
+    }
+
+}


### PR DESCRIPTION
Raised in #100 this PR adds support for automatic retry of requests to AWS. 

Some breaking changes are present in terms of making the Multipart utility classes consistent with the naming and behaviour of retry logic globally. This means for example some method name changes (Multipart builder retry methods) and MaxAttemptsExceededException is now only thrown when the http client throws (rather than returning a response with an http status code). For a retryable status code that reaches maxAttempts the final response is returned (effectively an error response).