### PR TITLE
add Automatic-Module-Name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,18 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.github.davidmoten.aws-lightweight-client-java</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>${m3.site.version}</version>
                 <executions>


### PR DESCRIPTION
As requested in #186, produces a MANIFEST.MF that looks like this:

```
Manifest-Version: 1.0
Automatic-Module-Name: com.github.davidmoten.aws-lightweight-client-ja
 va
Bnd-LastModified: 1730955562524
Build-Jdk-Spec: 21
Bundle-Description: Lightweight client for all AWS services (but still
  with useful builders and XML parser)
Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
Bundle-ManifestVersion: 2
Bundle-Name: aws-lightweight-client-java
Bundle-SymbolicName: com.github.davidmoten.aws-lightweight-client-java
Bundle-Version: 0.1.17.SNAPSHOT
Created-By: Apache Maven Bundle Plugin 5.1.9
Export-Package: com.github.davidmoten.aws.lw.client;uses:="com.github.
 davidmoten.aws.lw.client.xml";version="0.1.17",com.github.davidmoten.
 aws.lw.client.xml;version="0.1.17",com.github.davidmoten.aws.lw.clien
 t.xml.builder;version="0.1.17"
Import-Package: javax.crypto,javax.crypto.spec
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-6.3.1.202206071316
```