### PR TITLE
ensure Response.firstHeader(name) is case-insensitive and add Response.headersLowerCaseKey()

### DIFF
--- a/src/test/java/com/github/davidmoten/aws/lw/client/ResponseTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ResponseTest.java
@@ -98,6 +98,17 @@ public class ResponseTest {
         Response r = new Response(map, new byte[0], 100);
         assertEquals("a", r.firstHeader("thing").get());
     }
+    
+    @Test
+    public void testFirstHeaderIsCaseInsensitive() {
+        Map<String, List<String>> map = new HashMap<>();
+        List<String> v = Arrays.asList("a", "b");
+        map.put("Thing", v);
+        Response r = new Response(map, new byte[0], 100);
+        assertEquals("a", r.firstHeader("THING").get());
+        assertEquals(v, r.headers().get("Thing"));
+        assertEquals(v, r.headersLowerCaseKey().get("thing"));
+    }
 
     @Test
     public void testFirstHeaderFullDateNoHeaders() {


### PR DESCRIPTION
Discussed in #195

With this change I'm assuming there is some value in the headers being visible to the user with the actual returned names (rather than just converting all header names to lower case and losing sight of the original value). 