### PR TITLE
handle reserved chars in path parameters #216

### DIFF
--- a/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/Request.java
@@ -246,6 +246,7 @@ public final class Request {
             u = trimAndEnsureHasTrailingSlash(baseUrl) //
                     + pathSegments //
                             .stream() //
+                            .map(x -> Util.urlEncode(x, false)) //
                             .map(x -> trimAndRemoveLeadingAndTrailingSlashes(x)) //
                             .collect(Collectors.joining("/"));
         }

--- a/src/main/java/com/github/davidmoten/aws/lw/client/internal/auth/AwsSignatureVersion4.java
+++ b/src/main/java/com/github/davidmoten/aws/lw/client/internal/auth/AwsSignatureVersion4.java
@@ -338,7 +338,7 @@ public final class AwsSignatureVersion4 {
         if (path.isEmpty()) {
             return "/";
         } else {
-            return Util.urlEncode(path, true);
+            return path;
         }
     }
 

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientMain.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientMain.java
@@ -34,6 +34,8 @@ public final class ClientMain {
                 .credentials(credentials) //
                 .build();
         Client s3 = Client.s3().from(sqs).build();
+        System.out.println(s3.path("moten-fixes", "name with spaces.txt").responseAsUtf8());
+//        System.exit(0);
         System.out.println(s3.path("moten-fixes", "Neo4j_Graph_Algorithms_r3.mobi").presignedUrl(5,
                 TimeUnit.MINUTES));
         {

--- a/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
+++ b/src/test/java/com/github/davidmoten/aws/lw/client/ClientTest.java
@@ -656,7 +656,7 @@ public class ClientTest {
                 .build();
 
         s3 //
-                .path("myBucket/myObject.txt") //
+                .path("myBucket","myObject.txt") //
                 .query("Type", "Thing") //
                 .header("my-header", "blah") //
                 .header("my-header", "blah2") //


### PR DESCRIPTION
as discussed in #216

The fix will preclude use of 
```java
String text = s3
    .path(bucketName + "/" + objectName)
    .responseAsUtf8();
```
Instead users should pass the path elements as separate parameters:
```java
String text = s3
    .path(bucketName, objectName)
    .responseAsUtf8();
```

